### PR TITLE
Use GITHUB_OUTPUT instead of set-output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,4 +42,4 @@ runs:
         echo "${{ inputs.private-key }}" > /tmp/gh-app-private-key.pem
         TOKEN=$(/usr/local/bin/gh-app-auth --app-id "${{ inputs.app-id }}" --private-key "/tmp/gh-app-private-key.pem" --account "${{ inputs.account }}")
         echo "::add-mask::$TOKEN"
-        echo "::set-output name=token::$TOKEN"
+        echo "token=$TOKEN" >> $GITHUB_OUTPUT


### PR DESCRIPTION
cf. [GitHub Actions: Deprecating save-state and set-output commands | GitHub Changelog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

@summerwind Please review PR